### PR TITLE
Sidebar side toggle, per-feature keyboard shortcuts, and review auto-show

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 
 import os, sys, json, traceback, shutil
+from functools import partial
 from typing import Optional, Union, Any, Dict
 
 # --- Import Sub-Modules ---
@@ -52,6 +53,7 @@ except ImportError: pass
 modules_loaded = False
 try:
     from . import mode
+    from . import launcher_widget
     from .launcher_widget import SidebarWidget
     from .pomodoro import init_pomodoro, cleanup_pomodoro
     from .website_sidebar import cleanup_website_sidebar
@@ -89,6 +91,7 @@ gamification_manager: Optional[GamificationManager] = None
 gamification_sidebar: Optional[GamificationSidebar] = None
 learning_plan_manager: Optional[LearningPlanManager] = None
 deadline_manager: Optional[DeadlineManager] = None
+_feature_shortcut_objs: list = []  # live QShortcut objects for sidebar-feature keybinds
 
 # --- Settings Handling ---
 def get_default_settings() -> Dict[str, Any]:
@@ -96,8 +99,10 @@ def get_default_settings() -> Dict[str, Any]:
         "onboarding_completed": False,
         "theme_enabled": True,
         "active_theme": "medical_theme.css",
-        "fact_theme": "Medical", 
+        "fact_theme": "Medical",
         "sidebar_visibility_mode": "always_show",
+        "sidebar_side": "left",          # Which edge the launcher icon strip is glued to: "left" | "right"
+        "feature_shortcuts": {},         # Optional keyboard shortcuts per sidebar feature, e.g. {"ai": "Ctrl+Shift+A"}
         "gamification_widgets_enabled": True, "daily_widgets_enabled": True, 
         "deadline_bar_enabled": True, "statistics_widget_enabled": True,
         "deck_overview_enabled": True,
@@ -125,24 +130,169 @@ def save_addon_settings():
             json.dump(addon_settings, f, indent=4)
     except Exception as e: print(f"SynapsePro1 ERROR: Save settings: {e}")
 
+# --- Feature panel docks (the side panels that open from the launcher) ---
+# Feature panels always open on the RIGHT region of the screen. The launcher
+# icon strip is glued to whichever edge the user picks ("sidebar_side"); when
+# the launcher is also on the right, it stays outermost and panels open to its
+# left (inner side).
+def _feature_panel_dock_names() -> list:
+    return [
+        getattr(constants, "AI_ASSISTANT_DOCK_OBJECT_NAME", ""),
+        getattr(constants, "WEBSITE_DOCK_OBJECT_NAME", ""),
+        getattr(constants, "NOTEBOOK_DOCK_OBJECT_NAME", ""),
+        getattr(constants, "MINDMAP_DOCK_OBJECT_NAME", ""),
+    ]
+
+def place_feature_dock(dock):
+    """Dock a feature panel on the RIGHT region of the screen.
+
+    Registered onto ``constants.place_feature_dock`` so the individual feature
+    modules (AI, website, notebook, mind-map) can position their docks
+    consistently without each needing to know the launcher side. When the
+    launcher is also on the right, the launcher stays glued to the outer edge
+    and the panel opens to its left (inner side).
+    """
+    if not mw or QDockWidget is object or Qt is None:
+        return
+    try:
+        side = addon_settings.get("sidebar_side", "left")
+        mw.addDockWidget(Qt.DockWidgetArea.RightDockWidgetArea, dock)
+        # If the launcher strip is on the right too, keep it glued to the outer
+        # edge and let the feature open to its left (inner side).
+        if side == "right" and launcher_dock_widget is not None:
+            try:
+                mw.splitDockWidget(dock, launcher_dock_widget, Qt.Orientation.Horizontal)
+            except Exception:
+                pass
+        # Re-evaluate launcher visibility whenever this panel shows/hides, so a
+        # panel opened mid-review reveals the launcher (and closing re-hides it).
+        try:
+            dock.visibilityChanged.connect(lambda *_: update_launcher_review_visibility())
+        except Exception:
+            pass
+    except Exception as e:
+        print(f"SynapsePro: place_feature_dock error: {e}")
+
+def _any_feature_panel_visible() -> bool:
+    if not mw or QDockWidget is object:
+        return False
+    try:
+        for name in _feature_panel_dock_names():
+            if not name:
+                continue
+            d = mw.findChild(QDockWidget, name)
+            if d is not None and d.isVisible():
+                return True
+        if gamification_sidebar is not None and gamification_sidebar.isVisible():
+            return True
+    except Exception:
+        pass
+    return False
+
+def update_launcher_review_visibility():
+    """While reviewing with 'Hide while Reviewing', show the launcher only if a
+    feature panel is open (so the other sidebar options stay reachable)."""
+    if not launcher_dock_widget or not mw:
+        return
+    try:
+        mode_v = addon_settings.get("sidebar_visibility_mode", "always_show")
+        if mode_v == "hide_review" and mw.state == "review":
+            launcher_dock_widget.setVisible(_any_feature_panel_visible())
+    except RuntimeError:
+        pass
+
 # --- State Change Notification (Show/Hide Sidebar) ---
 def on_state_change(new_state: str, old_state: str):
     global launcher_dock_widget
-    if not launcher_dock_widget: 
+    if not launcher_dock_widget:
         return
-    
+
     try:
         mode = addon_settings.get("sidebar_visibility_mode", "always_show")
-        
+
         if mode == "hide_review":
             if new_state == "review":
-                launcher_dock_widget.setVisible(False)
+                # Keep the launcher visible if a feature panel is already open,
+                # so its other options remain reachable mid-review.
+                launcher_dock_widget.setVisible(_any_feature_panel_visible())
             else:
                 launcher_dock_widget.setVisible(True)
-                
-        
+
+
     except RuntimeError:
         pass
+
+# --- Sidebar-feature keyboard shortcuts ---
+def _run_feature_shortcut(feature_key: str):
+    """Trigger the same action as clicking a launcher icon, from a keybind."""
+    try:
+        if feature_key == "ai":
+            from .ai_assistant import toggle_ai_assistant_dock
+            toggle_ai_assistant_dock()
+        elif feature_key == "website":
+            from .website_sidebar import toggle_website_dock
+            toggle_website_dock()
+        elif feature_key == "notebook":
+            from .notebook_sidebar import toggle_notebook_dock
+            toggle_notebook_dock()
+        elif feature_key == "mindmap":
+            from .mindmap_sidebar import toggle_mindmap_dock
+            toggle_mindmap_dock()
+        elif feature_key == "gamification":
+            toggle_gamification_sidebar()
+        elif feature_key == "music":
+            from . import background_music
+            btn = getattr(sidebar_widget_instance, "_music_button", None)
+            background_music.toggle_music_menu(btn)
+        elif feature_key == "pomodoro":
+            from . import pomodoro
+            if hasattr(pomodoro, "start_pause_action"):
+                pomodoro.start_pause_action()
+        elif feature_key == "study_plan":
+            show_configuration_dialog()
+    except Exception as e:
+        print(f"SynapsePro: feature shortcut '{feature_key}' error: {e}")
+    # A panel may have just opened/closed — re-evaluate launcher visibility.
+    update_launcher_review_visibility()
+
+def register_feature_shortcuts():
+    """(Re)create global QShortcuts from addon_settings['feature_shortcuts']."""
+    global _feature_shortcut_objs
+    if not mw:
+        return
+    try:
+        if constants.qt_version == 6:
+            from PyQt6.QtGui import QShortcut, QKeySequence
+        else:
+            from PyQt5.QtWidgets import QShortcut
+            from PyQt5.QtGui import QKeySequence
+    except Exception as e:
+        print(f"SynapsePro: could not import QShortcut: {e}")
+        return
+
+    # Tear down any previously-registered shortcuts.
+    for sc in _feature_shortcut_objs:
+        try:
+            sc.setParent(None)
+            sc.deleteLater()
+        except Exception:
+            pass
+    _feature_shortcut_objs = []
+
+    shortcuts = addon_settings.get("feature_shortcuts", {}) or {}
+    for fkey, seq in shortcuts.items():
+        if not seq:
+            continue
+        try:
+            sc = QShortcut(QKeySequence(seq), mw)
+            try:
+                sc.setContext(Qt.ShortcutContext.ApplicationShortcut)
+            except Exception:
+                pass
+            sc.activated.connect(partial(_run_feature_shortcut, fkey))
+            _feature_shortcut_objs.append(sc)
+        except Exception as e:
+            print(f"SynapsePro: could not register shortcut '{seq}' for '{fkey}': {e}")
 
 # --- Startup & Logic ---
 def _apply_onboarding_result(result: dict):
@@ -346,6 +496,9 @@ def show_settings_dialog():
 
             deck_overview.update_settings(addon_settings)
 
+            # Re-apply keyboard shortcuts for sidebar features (live, no restart).
+            register_feature_shortcuts()
+
             if mw:
                 on_state_change(mw.state, mw.state)
 
@@ -358,6 +511,7 @@ def toggle_gamification_sidebar():
     if gamification_sidebar:
         if gamification_sidebar.isVisible(): gamification_sidebar.hide()
         else: gamification_sidebar.update_display(); gamification_sidebar.show(); gamification_sidebar.raise_()
+        update_launcher_review_visibility()
 
 def show_configuration_dialog():
     try:
@@ -442,30 +596,49 @@ def _init_ui_delayed():
     if addon_settings.get("daily_widgets_enabled", True) and not learning_plan_manager:
         learning_plan_manager = LearningPlanManager(study_plan_config_json_path); mw.learning_plan_manager = learning_plan_manager
 
-    if addon_settings.get("gamification_sidebar_enabled", True) and not gamification_sidebar and gamification_manager:
-        gamification_sidebar = GamificationSidebar(manager=gamification_manager, parent=mw)
-        mw.addDockWidget(Qt.DockWidgetArea.RightDockWidgetArea, gamification_sidebar)
-        gamification_sidebar.setVisible(False)
+    # --- Launcher icon strip (created first so feature panels can dock
+    #     relative to it and stay on the inner side). ---
+    sidebar_side = addon_settings.get("sidebar_side", "left")
+    launcher_area = (
+        Qt.DockWidgetArea.RightDockWidgetArea if sidebar_side == "right"
+        else Qt.DockWidgetArea.LeftDockWidgetArea
+    )
 
-    if addon_settings.get("notebook_enabled", True):
-        setup_notebook_sidebar()
-
-    # Left Sidebar (Launcher)
     launcher_dock_name = "MobesaLauncherSidebarDock_v2"
     existing = mw.findChild(QDockWidget, launcher_dock_name)
     if existing: existing.deleteLater()
-    
+
     launcher_dock_widget = QDockWidget("", mw)
     launcher_dock_widget.setObjectName(launcher_dock_name)
     sidebar_widget_instance = SidebarWidget(parent=launcher_dock_widget, settings_dialog_trigger=show_settings_dialog, settings=addon_settings)
     launcher_dock_widget.setWidget(sidebar_widget_instance)
     launcher_dock_widget.setFeatures(QDockWidget.DockWidgetFeature.NoDockWidgetFeatures)
-    launcher_dock_widget.setAllowedAreas(Qt.DockWidgetArea.LeftDockWidgetArea)
+    launcher_dock_widget.setAllowedAreas(launcher_area)
     launcher_dock_widget.setTitleBarWidget(QWidget())
     launcher_dock_widget.setFixedWidth(constants.SIDEBAR_WIDTH)
-    mw.addDockWidget(Qt.DockWidgetArea.LeftDockWidgetArea, launcher_dock_widget)
-    
+    mw.addDockWidget(launcher_area, launcher_dock_widget)
+
+    # Expose the panel-placement helper so feature modules dock consistently,
+    # and let the launcher notify us when a feature panel shows/hides.
+    constants.place_feature_dock = place_feature_dock
+    try:
+        launcher_widget.feature_visibility_callback = update_launcher_review_visibility
+    except Exception:
+        pass
+
+    # Gamification sidebar — a feature panel, so it opens on the left too.
+    if addon_settings.get("gamification_sidebar_enabled", True) and not gamification_sidebar and gamification_manager:
+        gamification_sidebar = GamificationSidebar(manager=gamification_manager, parent=mw)
+        place_feature_dock(gamification_sidebar)
+        gamification_sidebar.setVisible(False)
+
+    if addon_settings.get("notebook_enabled", True):
+        setup_notebook_sidebar()
+
     on_state_change(mw.state, "")
+
+    # Register any user-configured keyboard shortcuts for sidebar features.
+    register_feature_shortcuts()
 
     # Sub-Features Init
     if addon_settings.get("pomodoro_enabled", True): 
@@ -480,8 +653,14 @@ def _init_ui_delayed():
 
 def on_profile_close():
     global launcher_dock_widget, sidebar_widget_instance, gamification_manager, gamification_sidebar, learning_plan_manager, deadline_manager
+    global _feature_shortcut_objs
     if gamification_manager: gamification_manager.save_data()
     if deadline_manager: deadline_manager.save_data()
+
+    for sc in _feature_shortcut_objs:
+        try: sc.setParent(None); sc.deleteLater()
+        except Exception: pass
+    _feature_shortcut_objs = []
     
     cleanup_pomodoro(); cleanup_website_sidebar()
     cleanup_music_player(); cleanup_ai_assistant_sidebar()

--- a/ai_assistant.py
+++ b/ai_assistant.py
@@ -1269,7 +1269,11 @@ def _setup_sidebar() -> bool:
         _webview.setSizePolicy(QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Expanding)
         _dock.setWidget(_webview)
         _dock.setVisible(False)
-        mw.addDockWidget(Qt.DockWidgetArea.RightDockWidgetArea, _dock)
+        _place = getattr(constants, "place_feature_dock", None)
+        if callable(_place):
+            _place(_dock)
+        else:
+            mw.addDockWidget(Qt.DockWidgetArea.RightDockWidgetArea, _dock)
 
         # Hooks
         if not _hooks_connected and gui_hooks:

--- a/launcher_widget.py
+++ b/launcher_widget.py
@@ -87,6 +87,12 @@ if TYPE_CHECKING:
     from .study_plan_trigger import trigger_gamification_sidebar_action, trigger_study_plan_action
 
 
+# Optional callback invoked whenever a feature panel dock shows/hides.
+# Set by __init__.py so the launcher can be auto-revealed mid-review when a
+# panel is open. Left as None when running standalone.
+feature_visibility_callback = None
+
+
 class SidebarWidget(QWidget):
     def __init__(self, parent: Optional['QWidget'] = None, settings_dialog_trigger: Optional[Callable] = None, settings: Optional[Dict[str, Any]] = None):
         if QWidget is object: return
@@ -317,6 +323,14 @@ class SidebarWidget(QWidget):
 
     def _update_button_active_state_from_ref(self, is_visible: bool, button_weak_ref: weakref.ReferenceType['PushButtonType']):
         if button := button_weak_ref(): self._update_button_active_state(is_visible, button)
+        # Notify the host (__init__) so it can re-reveal the launcher mid-review
+        # when a feature panel is open.
+        cb = globals().get("feature_visibility_callback")
+        if callable(cb):
+            try:
+                cb()
+            except Exception:
+                pass
 
     def _update_button_active_state(self, is_visible: bool, button: 'PushButtonType'):
         if not button or not button.isCheckable() or not button.property("isMainIconButton"): return

--- a/mindmap_sidebar.py
+++ b/mindmap_sidebar.py
@@ -285,7 +285,11 @@ def setup_mindmap_dock():
         
         mindmap_dock.visibilityChanged.connect(panel.on_visibility_changed)
 
-        if Qt: mw.addDockWidget(Qt.DockWidgetArea.RightDockWidgetArea, mindmap_dock)
+        _place = getattr(constants, "place_feature_dock", None)
+        if callable(_place):
+            _place(mindmap_dock)
+        elif Qt:
+            mw.addDockWidget(Qt.DockWidgetArea.RightDockWidgetArea, mindmap_dock)
         mindmap_dock.setVisible(False)
 
     except Exception as e:

--- a/notebook_sidebar.py
+++ b/notebook_sidebar.py
@@ -951,7 +951,15 @@ def _ensure_dock() -> QDockWidget:
 
     _dock.visibilityChanged.connect(_on_visibility_changed)
 
-    mw.addDockWidget(Qt.DockWidgetArea.RightDockWidgetArea, _dock)
+    try:
+        from . import constants as _constants
+        _place = getattr(_constants, "place_feature_dock", None)
+    except Exception:
+        _place = None
+    if callable(_place):
+        _place(_dock)
+    else:
+        mw.addDockWidget(Qt.DockWidgetArea.RightDockWidgetArea, _dock)
     return _dock
 
 

--- a/settings_dialog.py
+++ b/settings_dialog.py
@@ -25,21 +25,22 @@ try:
         from PyQt6.QtWidgets import (QDialog, QVBoxLayout, QLabel, QDialogButtonBox,
                                      QCheckBox, QWidget, QGridLayout, QFrame, QComboBox,
                                      QGroupBox, QScrollArea, QPushButton, QHBoxLayout,
-                                     QSizePolicy, QApplication)
-        from PyQt6.QtGui import QPixmap, QDesktopServices
+                                     QSizePolicy, QApplication, QKeySequenceEdit, QLineEdit)
+        from PyQt6.QtGui import QPixmap, QDesktopServices, QKeySequence
         from PyQt6.QtCore import Qt, QUrl, QTimer
     elif constants.qt_version == 5:
         from PyQt5.QtWidgets import (QDialog, QVBoxLayout, QLabel, QDialogButtonBox,
                                      QCheckBox, QWidget, QGridLayout, QFrame, QComboBox,
                                      QGroupBox, QScrollArea, QPushButton, QHBoxLayout,
-                                     QSizePolicy, QApplication)
-        from PyQt5.QtGui import QPixmap, QDesktopServices
+                                     QSizePolicy, QApplication, QKeySequenceEdit, QLineEdit)
+        from PyQt5.QtGui import QPixmap, QDesktopServices, QKeySequence
         from PyQt5.QtCore import Qt, QUrl, QTimer
     else:
         raise ImportError("No valid Qt version found for SettingsDialog")
 except ImportError as e:
     print(f"SettingsDialog Error: Failed to import required modules: {e}")
     QDialog, QVBoxLayout, QLabel, QDialogButtonBox, QCheckBox, QWidget, QGridLayout, QFrame, Qt, QPixmap, QComboBox, QGroupBox, QScrollArea, QPushButton, QHBoxLayout, QDesktopServices, QUrl, QSizePolicy, QApplication, QTimer = (object,) * 20
+    QKeySequenceEdit, QKeySequence, QLineEdit = object, object, object
 
 # --- Night Mode Detection ---
 is_night_mode = False
@@ -111,6 +112,7 @@ class SettingsDialog(QDialog):
         super().__init__(parent)
         self.current_config = current_config
         self.checkboxes = {}
+        self.shortcut_edits = {}  # shortcut feature-key -> QKeySequenceEdit
         self._info_image_label = None
         self._info_pixmap_original = None
         self._compact_mode = False
@@ -688,27 +690,50 @@ class SettingsDialog(QDialog):
         card.setSizePolicy(QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Preferred)
         layout = QVBoxLayout(card)
         layout.setContentsMargins(16, 16, 16, 16)
-        layout.setSpacing(2)
+        layout.setSpacing(5)
 
         header = QLabel(_("Sidebar"))
         header.setObjectName("SubHeaderLabel")
         header.setAlignment(Qt.AlignmentFlag.AlignCenter)
         layout.addWidget(header)
 
+        # --- Sidebar side (which edge the icon strip is glued to) ----------
+        side_row = QHBoxLayout()
+        side_row.setSpacing(8)
+        side_lbl = QLabel(_("Sidebar Side:"))
+        side_lbl.setSizePolicy(QSizePolicy.Policy.Preferred, QSizePolicy.Policy.Fixed)
+        side_row.addWidget(side_lbl)
+        self.sidebar_side_combo = QComboBox()
+        self.sidebar_side_combo.setSizePolicy(QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Fixed)
+        self.sidebar_side_combo.addItem(_("Left"), "left")
+        self.sidebar_side_combo.addItem(_("Right"), "right")
+        s_idx = self.sidebar_side_combo.findData(self.current_config.get("sidebar_side", "left"))
+        self.sidebar_side_combo.setCurrentIndex(s_idx if s_idx != -1 else 0)
+        side_row.addWidget(self.sidebar_side_combo, 1)
+        layout.addLayout(side_row)
+
+        kb_hint = QLabel(_("Toggle each feature below, and optionally set a keyboard shortcut on the right."))
+        kb_hint.setObjectName("HintText")
+        kb_hint.setWordWrap(True)
+        layout.addWidget(kb_hint)
+        layout.addSpacing(4)
+
+        # Each entry: (setting key, label, shortcut feature-key).
+        # A shortcut key of None means no keybind editor for that row.
         features = [
-            ("mindmap_enabled", _("Mind Map")),
-            ("gamification_sidebar_enabled", _("Gamification Sidebar")),
-            ("music_player_enabled", _("Music Player")),
-            ("pomodoro_enabled", _("Pomodoro Timer")),
-            ("ai_assistant_enabled", _("AI Assistant")),
-            ("website_viewer_enabled", _("Website Viewer")),
-            ("notebook_enabled", _("Notebook")),
+            ("mindmap_enabled", _("Mind Map"), "mindmap"),
+            ("gamification_sidebar_enabled", _("Gamification Sidebar"), "gamification"),
+            ("music_player_enabled", _("Music Player"), "music"),
+            ("pomodoro_enabled", _("Pomodoro Timer"), "pomodoro"),
+            ("ai_assistant_enabled", _("AI Assistant"), "ai"),
+            ("website_viewer_enabled", _("Website Viewer"), "website"),
+            ("notebook_enabled", _("Notebook"), "notebook"),
         ]
-        for key, text in features:
-            self.add_checkbox(key, text, layout)
+        for key, text, shortcut_key in features:
+            self.add_feature_row(key, text, layout, shortcut_key)
 
         layout.addSpacing(8)
-        hint = QLabel(_("You need to restart Anki to see the changes of the Sidebar Settings."))
+        hint = QLabel(_("You need to restart Anki to see the changes of the Sidebar Settings (shortcuts apply immediately)."))
         hint.setObjectName("HintText")
         hint.setWordWrap(True)
         layout.addWidget(hint)
@@ -726,6 +751,97 @@ class SettingsDialog(QDialog):
             pass
         self.checkboxes[key] = cb
         layout.addWidget(cb)
+
+    def add_feature_row(self, key, text, layout, shortcut_key):
+        """A feature toggle (checkbox) with an optional keyboard-shortcut editor
+        on the right, plus a small clear button."""
+        row = QHBoxLayout()
+        row.setContentsMargins(0, 0, 0, 0)
+        row.setSpacing(6)
+
+        cb = QCheckBox(text)
+        cb.setCursor(Qt.CursorShape.PointingHandCursor)
+        cb.setChecked(bool(self.current_config.get(key, True)))
+        try:
+            cb.setSizePolicy(QSizePolicy.Policy.Preferred, QSizePolicy.Policy.Preferred)
+        except Exception:
+            pass
+        self.checkboxes[key] = cb
+        row.addWidget(cb, 1)
+
+        if shortcut_key and QKeySequenceEdit is not object:
+            c = _palette(is_night_mode)
+            surface = c.get("surface", "#FFFFFF")
+            border  = c.get("grey_mid", "#D1D1D6")
+            focus   = c.get("blue_bright", "#007AFF")
+            text_c  = c.get("text", "#1D1D1F")
+            muted   = c.get("text_muted", "#86868B")
+            hover   = c.get("hover_subtle", "#F0F0F0")
+
+            kse = QKeySequenceEdit()
+            kse.setFixedSize(124, 28)
+            kse.setToolTip(_("Click, then press a key combination (e.g. Ctrl+Shift+A)."))
+            existing = (self.current_config.get("feature_shortcuts", {}) or {}).get(shortcut_key, "")
+            if existing:
+                try:
+                    kse.setKeySequence(QKeySequence(existing))
+                except Exception:
+                    pass
+            # Themed pill that matches the dialog's combos/inputs; turns the
+            # accent colour while it is capturing a key combo.
+            kse.setStyleSheet(f"""
+                QKeySequenceEdit {{
+                    background: transparent;
+                    border: none;
+                }}
+                QKeySequenceEdit QLineEdit {{
+                    background-color: {surface};
+                    border: 1px solid {border};
+                    border-radius: 8px;
+                    padding: 2px 8px;
+                    color: {text_c};
+                    font-size: 12px;
+                    selection-background-color: {focus};
+                    selection-color: white;
+                }}
+                QKeySequenceEdit QLineEdit:focus {{
+                    border: 1px solid {focus};
+                }}
+            """)
+            # Placeholder hint so an empty field reads clearly.
+            if QLineEdit is not object:
+                try:
+                    _le = kse.findChild(QLineEdit)
+                    if _le is not None:
+                        _le.setPlaceholderText(_("Set shortcut…"))
+                        _le.setAlignment(Qt.AlignmentFlag.AlignCenter)
+                except Exception:
+                    pass
+            self.shortcut_edits[shortcut_key] = kse
+            row.addWidget(kse, 0)
+
+            clear_btn = QPushButton("✕")
+            clear_btn.setToolTip(_("Clear shortcut"))
+            clear_btn.setFixedSize(28, 28)
+            clear_btn.setCursor(Qt.CursorShape.PointingHandCursor)
+            clear_btn.setStyleSheet(f"""
+                QPushButton {{
+                    background-color: transparent;
+                    color: {muted};
+                    border: none;
+                    border-radius: 14px;
+                    font-size: 13px;
+                    padding: 0px;
+                    min-width: 0px;
+                }}
+                QPushButton:hover {{ background-color: {hover}; color: {text_c}; }}
+                QPushButton:pressed {{ background-color: {border}; }}
+            """)
+            clear_btn.clicked.connect(kse.clear)
+            clear_btn.clicked.connect(lambda: kse.setFocus())
+            row.addWidget(clear_btn, 0)
+
+        layout.addLayout(row)
 
     def add_button_row(self):
         """Save / Cancel row. Lives OUTSIDE the scroll area so it is always
@@ -880,8 +996,20 @@ class SettingsDialog(QDialog):
             "custom_theme_colors": getattr(self, "_custom_theme_colors", {}),
             "stats_time_range": int(self.stats_range_combo.currentData() or 7),
             "sidebar_visibility_mode": self.sidebar_vis_combo.currentData() or "always_show",
+            "sidebar_side": self.sidebar_side_combo.currentData() or "left",
             "language": self.language_combo.currentData() or "auto",
         }
         for key, cb in self.checkboxes.items():
             settings[key] = cb.isChecked()
+
+        # Collect per-feature keyboard shortcuts (only non-empty ones).
+        feature_shortcuts = {}
+        for fkey, kse in getattr(self, "shortcut_edits", {}).items():
+            try:
+                seq = kse.keySequence().toString()
+            except Exception:
+                seq = ""
+            if seq:
+                feature_shortcuts[fkey] = seq
+        settings["feature_shortcuts"] = feature_shortcuts
         return settings

--- a/website_sidebar.py
+++ b/website_sidebar.py
@@ -444,8 +444,12 @@ def create_website_dock() -> Optional[QDockWidget]:
 
         sidebar_dock.setWidget(container_widget)
         sidebar_dock.setVisible(False)
-        add_dock_area_enum = Qt.DockWidgetArea if hasattr(Qt, 'DockWidgetArea') else Qt
-        mw.addDockWidget(add_dock_area_enum.RightDockWidgetArea, sidebar_dock)
+        _place = getattr(constants, "place_feature_dock", None)
+        if callable(_place):
+            _place(sidebar_dock)
+        else:
+            add_dock_area_enum = Qt.DockWidgetArea if hasattr(Qt, 'DockWidgetArea') else Qt
+            mw.addDockWidget(add_dock_area_enum.RightDockWidgetArea, sidebar_dock)
         print(f"WS Info: New dock created and added successfully.")
 
     except Exception as e:


### PR DESCRIPTION
## Summary

Three related sidebar quality-of-life additions, all configured from the **Settings → Sidebar** card:

### 1. Left / Right sidebar side
A **"Sidebar Side"** selector glues the launcher icon strip to the left or right edge of the window (default: left, unchanged from current behaviour). Takes effect after an Anki restart, consistent with the other sidebar settings.

### 2. Per-feature keyboard shortcuts
Each sidebar feature toggle now has an optional, themed key-capture field (and a clear button) beside it. Shortcuts are registered as global Anki `QShortcut`s and apply **immediately on save** — no restart needed. Covers AI Assistant, Website Viewer, Notebook, Mind Map, Gamification Sidebar, Music Player and Pomodoro.

### 3. Reveal the strip mid-review when a panel is open
With **"Hide while Reviewing"** enabled, the launcher strip previously disappeared entirely during review. Now it stays hidden only while no feature panel is open — opening a panel (e.g. via a new keyboard shortcut) reveals the strip so the other options stay reachable, and closing the panel hides it again.

## Implementation notes
- Feature panels are positioned through a single shared `constants.place_feature_dock` helper instead of each module hardcoding its dock area, so they open consistently. When the launcher shares the same edge, it stays glued to the outer side and the panel opens inner.
- New settings keys: `sidebar_side`, `feature_shortcuts`. Both have safe defaults, so existing configs are unaffected.
- Shortcut fields are styled from the active colour-theme palette to match the rest of the add-on (light/dark aware).

## Testing
- Verified on PyQt6. Toggled side left/right; set/cleared shortcuts; confirmed shortcuts open/close the correct panels live; confirmed the strip reveals on panel-open and hides on panel-close while reviewing with "Hide while Reviewing".

🤖 Generated with [Claude Code](https://claude.com/claude-code)