### PR TITLE
Add llama.cpp server as an AI provider

### DIFF
--- a/ai_assistant.py
+++ b/ai_assistant.py
@@ -130,6 +130,7 @@ def _get_theme_accent(is_dark: bool) -> str:
 DOCK_NAME     = "AIAssistantSidebarDock_Integrated_v1"
 HTML_FILENAME = "chat_ui.html"
 OLLAMA_EP_DEFAULT = "http://localhost:11434"
+LLAMA_EP_DEFAULT  = "http://localhost:8080"
 
 PREFERRED_FRONT = ["Vorderseite","Front","Question","Text","Frage","Prompt","Front Side"]
 PREFERRED_BACK  = ["Rückseite","Back","Answer","Antwort","Back Side"]
@@ -159,6 +160,9 @@ CK_KEY_OR     = _PFX + "key_openrouter"
 CK_KEY_ANTH   = _PFX + "key_anthropic"
 CK_OLLAMA_EP  = _PFX + "ollama_endpoint"
 CK_OLLAMA_MDL = _PFX + "ollama_model"
+CK_LLAMA_EP   = _PFX + "llama_endpoint"
+CK_LLAMA_MDL  = _PFX + "llama_model"
+CK_KEY_LLAMA  = _PFX + "key_llama"
 CK_LANGUAGE   = _PFX + "language"
 CK_SOURCE     = _PFX + "source"
 CK_OWN_PROMPT = _PFX + "own_prompt"
@@ -241,7 +245,15 @@ def _load_settings() -> Dict[str, Any]:
     current_key    = key_map.get(provider, "")
     ollama_ep      = _cfg_get(CK_OLLAMA_EP, OLLAMA_EP_DEFAULT)
     ollama_model   = _cfg_get(CK_OLLAMA_MDL, "")
-    effective_model = ollama_model if provider == "ollama" else _cfg_get(CK_MODEL, "")
+    llama_ep       = _cfg_get(CK_LLAMA_EP, LLAMA_EP_DEFAULT)
+    llama_model    = _cfg_get(CK_LLAMA_MDL, "")
+    if provider == "ollama":
+        effective_model = ollama_model
+    elif provider == "llamaserver":
+        effective_model = llama_model
+        current_key     = _cfg_get(CK_KEY_LLAMA, "")
+    else:
+        effective_model = _cfg_get(CK_MODEL, "")
     return {
         "provider":     provider,
         "model":        effective_model,
@@ -250,6 +262,7 @@ def _load_settings() -> Dict[str, Any]:
         "source":       _cfg_get(CK_SOURCE,    "Front & Back"),
         "ownPrompt":    _cfg_get(CK_OWN_PROMPT, DEFAULT_OWN_PROMPT),
         "ollamaEndpoint": ollama_ep,
+        "llamaEndpoint":  llama_ep,
         "isDark":         _detect_night_mode(),
         "isConfigured":   _is_configured(provider, current_key),
         "chipsConfig":    _cfg_get(CK_CHIPS, _DEFAULT_CHIPS),
@@ -258,13 +271,15 @@ def _load_settings() -> Dict[str, Any]:
     }
 
 def _is_configured(provider: str, api_key: str) -> bool:
-    return provider == "ollama" or bool(api_key and api_key.strip())
+    # Local providers (Ollama, llama.cpp server) don't require an API key.
+    return provider in ("ollama", "llamaserver") or bool(api_key and api_key.strip())
 
 def _save_settings_dict(data: Dict[str, Any]) -> None:
     provider  = data.get("provider", "openai")
     api_key   = data.get("apiKey", "").strip()
     model     = data.get("model", "").strip()
     ollama_ep = data.get("ollamaEndpoint", OLLAMA_EP_DEFAULT).strip() or OLLAMA_EP_DEFAULT
+    llama_ep  = data.get("llamaEndpoint", LLAMA_EP_DEFAULT).strip() or LLAMA_EP_DEFAULT
 
     _cfg_set(CK_PROVIDER,   provider)
     _cfg_set(CK_LANGUAGE,   data.get("language",  "English"))
@@ -274,10 +289,16 @@ def _save_settings_dict(data: Dict[str, Any]) -> None:
         _cfg_set(CK_FONT_SIZE, font_size)
     _cfg_set(CK_OWN_PROMPT, data.get("ownPrompt", DEFAULT_OWN_PROMPT))
     _cfg_set(CK_OLLAMA_EP,  ollama_ep)
+    _cfg_set(CK_LLAMA_EP,   llama_ep)
 
     if provider == "ollama":
         if model:
             _cfg_set(CK_OLLAMA_MDL, model)
+    elif provider == "llamaserver":
+        if model:
+            _cfg_set(CK_LLAMA_MDL, model)
+        # API key is optional for llama.cpp (only set when --api-key is used).
+        _cfg_set(CK_KEY_LLAMA, api_key)
     else:
         if model:
             _cfg_set(CK_MODEL, model)
@@ -290,8 +311,10 @@ def _save_settings_dict(data: Dict[str, Any]) -> None:
         if provider in key_cfg and api_key:
             _cfg_set(key_cfg[provider], api_key)
 
+    _ep_log = ollama_ep if provider == "ollama" else (
+        llama_ep if provider == "llamaserver" else "n/a")
     print(f"AI Assistant: settings saved — provider={provider}, model={model}, "
-          f"endpoint={ollama_ep if provider=='ollama' else 'n/a'}, "
+          f"endpoint={_ep_log}, "
           f"key={'(set)' if api_key else '(empty)'}")
 
 
@@ -396,16 +419,18 @@ def _stream_openai_compat(
     on_chunk: Callable[[str], None],
     extra_headers: Optional[Dict[str, str]] = None,
     timeout: int = 60,
+    on_reasoning: Optional[Callable[[str], None]] = None,
 ) -> None:
-    """OpenAI-compatible streaming (also used for OpenRouter)."""
+    """OpenAI-compatible streaming (also used for OpenRouter & llama.cpp server)."""
     print(f"AI Assistant: streaming OpenAI-compat url={url.split('/')[2]}, model={model}")
     payload = json.dumps({
         "model": model, "messages": messages, "max_tokens": 2048, "stream": True,
     }).encode("utf-8")
-    headers: Dict[str, str] = {
-        "Authorization": f"Bearer {api_key}",
-        "Content-Type":  "application/json",
-    }
+    headers: Dict[str, str] = {"Content-Type": "application/json"}
+    # API key is optional for self-hosted OpenAI-compatible servers (e.g. a
+    # llama.cpp server started without --api-key). Only send auth when present.
+    if api_key:
+        headers["Authorization"] = f"Bearer {api_key}"
     if extra_headers:
         headers.update(extra_headers)
     req = urllib.request.Request(url, data=payload, headers=headers, method="POST")
@@ -421,9 +446,16 @@ def _stream_openai_compat(
                 ev      = json.loads(data_str)
                 choices = ev.get("choices") or []
                 if choices:
-                    content = (choices[0].get("delta") or {}).get("content") or ""
+                    delta   = choices[0].get("delta") or {}
+                    content = delta.get("content") or ""
                     if content:
                         on_chunk(content)
+                    if on_reasoning:
+                        # llama.cpp/Qwen/DeepSeek use "reasoning_content";
+                        # OpenRouter exposes "reasoning".
+                        rc = delta.get("reasoning_content") or delta.get("reasoning") or ""
+                        if rc:
+                            on_reasoning(rc)
             except Exception:
                 pass
 
@@ -586,6 +618,7 @@ def _run_api_in_thread(settings: Dict[str, Any], messages: List[Dict]) -> None:
         model     = settings.get("model", "")
         api_key   = settings.get("apiKey", "")
         ollama_ep = settings.get("ollamaEndpoint", OLLAMA_EP_DEFAULT)
+        llama_ep  = settings.get("llamaEndpoint", LLAMA_EP_DEFAULT)
         full_text: List[str] = []
 
         if not model:
@@ -597,6 +630,11 @@ def _run_api_in_thread(settings: Dict[str, Any], messages: List[Dict]) -> None:
             full_text.append(chunk)
             _js_on_main(f"appendChunk({json.dumps(chunk)});")
 
+        def on_reasoning(chunk: str) -> None:
+            # Streamed to a separate "Thinking" area; intentionally NOT added to
+            # full_text so the model's reasoning stays out of the saved answer.
+            _js_on_main(f"appendThinking({json.dumps(chunk)});")
+
         try:
             # Signal JS to create the streaming bubble (hides typing indicator)
             _js_on_main("startAIBubble();")
@@ -605,6 +643,7 @@ def _run_api_in_thread(settings: Dict[str, Any], messages: List[Dict]) -> None:
                 _stream_openai_compat(
                     "https://api.openai.com/v1/chat/completions",
                     api_key, model, messages, on_chunk,
+                    on_reasoning=on_reasoning,
                 )
             elif provider == "gemini":
                 _stream_gemini(api_key, model, messages, on_chunk)
@@ -616,11 +655,21 @@ def _run_api_in_thread(settings: Dict[str, Any], messages: List[Dict]) -> None:
                         "HTTP-Referer": "https://synapse-pro.vercel.app/",
                         "X-Title":      "SynapsePro",
                     },
+                    on_reasoning=on_reasoning,
                 )
             elif provider == "anthropic":
                 _stream_anthropic(api_key, model, messages, on_chunk)
             elif provider == "ollama":
                 _stream_ollama(model, messages, ollama_ep, on_chunk)
+            elif provider == "llamaserver":
+                # llama.cpp server exposes an OpenAI-compatible endpoint.
+                base = llama_ep.rstrip("/")
+                _stream_openai_compat(
+                    f"{base}/v1/chat/completions",
+                    api_key, model, messages, on_chunk,
+                    timeout=180,
+                    on_reasoning=on_reasoning,
+                )
             else:
                 raise RuntimeError(f"Unknown provider: '{provider}'")
 
@@ -839,6 +888,7 @@ def _handle_action(action: str, data: Dict[str, Any]) -> None:
         "save_chips":    _action_save_chips,
         "check_ollama":  _action_check_ollama,
         "setup_ollama":  _action_setup_ollama,
+        "check_llama":   _action_check_llama,
         "clear_history": _action_clear_history,
     }
     handler = dispatch.get(action)
@@ -944,6 +994,30 @@ def _action_check_ollama(_data: Optional[Dict] = None) -> None:
         except Exception as exc:
             print(f"AI Assistant: Ollama check failed: {exc}")
             _js_on_main("setOllamaStatus('stopped', []);")
+
+    threading.Thread(target=worker, daemon=True).start()
+
+
+def _action_check_llama(_data: Optional[Dict] = None) -> None:
+    """Check if a llama.cpp server is reachable; send result + models to JS."""
+    print("AI Assistant: checking llama.cpp server status…")
+
+    def worker():
+        ep = _cfg_get(CK_LLAMA_EP, LLAMA_EP_DEFAULT).rstrip("/")
+        key = _cfg_get(CK_KEY_LLAMA, "")
+        print(f"AI Assistant: connecting to llama.cpp server at {ep}")
+        try:
+            req = urllib.request.Request(f"{ep}/v1/models")
+            if key:
+                req.add_header("Authorization", f"Bearer {key}")
+            with urllib.request.urlopen(req, timeout=5) as resp:
+                result = json.loads(resp.read().decode("utf-8"))
+            models = [m["id"] for m in result.get("data", []) if m.get("id")]
+            print(f"AI Assistant: llama.cpp server running, models={models}")
+            _js_on_main(f"setLlamaStatus('running', {json.dumps(models)});")
+        except Exception as exc:
+            print(f"AI Assistant: llama.cpp check failed: {exc}")
+            _js_on_main("setLlamaStatus('stopped', []);")
 
     threading.Thread(target=worker, daemon=True).start()
 
@@ -1115,7 +1189,7 @@ if _qt_ok and QDialog is not object:
                         line = raw.decode("utf-8", errors="replace").strip()
                         if not line: continue
                         try: ev = json.loads(line)
-                        except Exception: continue
+                        except: continue
                         if "error" in ev: raise RuntimeError(ev["error"])
                         if "total" in ev:
                             total = int(ev.get("total", 0) or 0)

--- a/chat_ui.html
+++ b/chat_ui.html
@@ -325,6 +325,7 @@ body:not(.empty) #disclaimer{display:block}
         <option value="openrouter">OpenRouter</option>
         <option value="anthropic">Anthropic Claude</option>
         <option value="ollama">Ollama (Local)</option>
+        <option value="llamaserver">llama.cpp Server (Local)</option>
       </select>
     </div>
     <div class="s-row" id="s-apikey-row">
@@ -344,6 +345,15 @@ body:not(.empty) #disclaimer{display:block}
     <div class="s-row" id="s-ollama-row" style="display:none">
       <label class="s-label">Ollama Status</label>
       <div id="ollama-status-line">Checking...</div>
+    </div>
+    <div class="s-row" id="s-llama-ep-row" style="display:none">
+      <label class="s-label">Server Endpoint</label>
+      <input class="s-input" type="url" id="s-llama-ep" placeholder="http://localhost:8080" autocomplete="off"/>
+      <div class="s-hint">Base URL of your llama.cpp server (the OpenAI-compatible <code>/v1</code> path is added automatically).</div>
+    </div>
+    <div class="s-row" id="s-llama-row" style="display:none">
+      <label class="s-label">Server Status</label>
+      <div id="llama-status-line">Checking...</div>
     </div>
     <div class="s-section">
       <div class="s-row">
@@ -532,7 +542,8 @@ var MODELS = {
     'deepseek/deepseek-chat-v3-0324:free','mistralai/mistral-7b-instruct:free'
   ],
   anthropic:  ['claude-haiku-4-5-20251001','claude-sonnet-4-6','claude-opus-4-6'],
-  ollama:     []
+  ollama:     [],
+  llamaserver: []
 };
 
 // ── Built-in chips ────────────────────────────────────────────────────────────
@@ -556,6 +567,9 @@ var chipConfig   = {
 // ── Streaming state ───────────────────────────────────────────────────────────
 var _streamBubble = null;
 var _streamRaw    = '';
+var _streamAnswer = null;   // answer sub-element (separate from "thinking")
+var _streamThink  = '';     // accumulated reasoning_content (reasoning models)
+var _thinkEl      = null;   // <details> disclosure holding the reasoning
 
 // ── Accent color ──────────────────────────────────────────────────────────────
 var ACCENT_PRESETS = ['#3b82f6','#6366f1','#8b5cf6','#ec4899','#10b981','#f59e0b','#ef4444'];
@@ -596,6 +610,7 @@ function init(cfg) {
   safeSet('s-language', cfg.language  || 'English');
   safeSet('s-source',   cfg.source    || 'Front Only');
   document.getElementById('s-ollama-ep').value = cfg.ollamaEndpoint || 'http://localhost:11434';
+  document.getElementById('s-llama-ep').value  = cfg.llamaEndpoint  || 'http://localhost:8080';
 
   // Accent color
   var accent = cfg.accentColor || (cfg.isDark ? '#6366f1' : '#3b82f6');
@@ -610,6 +625,8 @@ function init(cfg) {
 
   if (cfg.provider === 'ollama') {
     setOllamaStatus(cfg.ollamaRunning ? 'running' : 'stopped', cfg.ollamaModels || []);
+  } else if (cfg.provider === 'llamaserver') {
+    sendToPython('check_llama', {});
   }
 
   if (cfg.chipsConfig) {
@@ -889,21 +906,31 @@ function onProviderChange(resetModel) {
   if (resetModel === undefined) resetModel = true;
   var prov     = document.getElementById('s-provider').value;
   var isOllama = prov === 'ollama';
+  var isLlama  = prov === 'llamaserver';
+  // Local providers don't require an API key; llama.cpp may use an optional one.
   document.getElementById('s-apikey-row').style.display    = isOllama ? 'none' : '';
   document.getElementById('s-ollama-ep-row').style.display = isOllama ? '' : 'none';
   document.getElementById('s-ollama-row').style.display    = isOllama ? '' : 'none';
+  document.getElementById('s-llama-ep-row').style.display  = isLlama  ? '' : 'none';
+  document.getElementById('s-llama-row').style.display     = isLlama  ? '' : 'none';
+  var apikey = document.getElementById('s-apikey');
+  apikey.placeholder = isLlama ? 'Optional — only if server uses --api-key'
+                               : 'Enter your API key...';
   var inp = document.getElementById('s-model');
   var dl  = document.getElementById('s-model-list');
   dl.innerHTML = '';
-  if (!isOllama) {
+  if (isOllama) {
+    inp.placeholder = 'Fetching models...';
+    sendToPython('check_ollama', {});
+  } else if (isLlama) {
+    inp.placeholder = 'Model name (e.g. the model your server loaded)';
+    sendToPython('check_llama', {});
+  } else {
     (MODELS[prov] || []).forEach(function(m) {
       var o = document.createElement('option'); o.value = m; dl.appendChild(o);
     });
     if (resetModel && MODELS[prov] && MODELS[prov].length) inp.value = MODELS[prov][0];
     inp.placeholder = 'Select or type a model...';
-  } else {
-    inp.placeholder = 'Fetching models...';
-    sendToPython('check_ollama', {});
   }
 }
 
@@ -931,6 +958,25 @@ function setOllamaStatus(status, models) {
   }
 }
 
+function setLlamaStatus(status, models) {
+  var el = document.getElementById('llama-status-line');
+  if (!el) return;
+  if (status === 'running') {
+    el.innerHTML = '<span style="color:var(--success)">Reachable</span>';
+    // Offer the loaded model(s) as suggestions, but allow any custom name.
+    var inp = document.getElementById('s-model');
+    var dl  = document.getElementById('s-model-list');
+    dl.innerHTML = '';
+    if (models && models.length) {
+      models.forEach(function(m) { var o = document.createElement('option'); o.value = m; dl.appendChild(o); });
+      if (!inp.value) inp.value = models[0];
+    }
+  } else {
+    el.innerHTML = '<span style="color:var(--error)">Not reachable</span>' +
+      ' &mdash; check the endpoint and that the server is running.';
+  }
+}
+
 function saveSettings() {
   var data = {
     provider:       document.getElementById('s-provider').value,
@@ -940,13 +986,14 @@ function saveSettings() {
     source:         document.getElementById('s-source').value,
     ownPrompt:      '',
     ollamaEndpoint: document.getElementById('s-ollama-ep').value.trim() || 'http://localhost:11434',
+    llamaEndpoint:  document.getElementById('s-llama-ep').value.trim() || 'http://localhost:8080',
     fontSize:       document.getElementById('s-fontsize').value || '13px'
   };
   setFontSize(data.fontSize);
   console.log('AI Assistant: save_settings provider=' + data.provider + ' model=' + data.model);
   sendToPython('save_settings', data);
   var banner    = document.getElementById('setup-banner');
-  var configured = (data.provider === 'ollama') || !!data.apiKey;
+  var configured = (data.provider === 'ollama') || (data.provider === 'llamaserver') || !!data.apiKey;
   if (configured) {
     banner.style.display = 'none';
     delete banner.dataset.showOnActive;
@@ -964,7 +1011,7 @@ function saveSettings() {
 function updateModelLabel() {
   var p = document.getElementById('s-provider').value;
   var m = document.getElementById('s-model').value || '';
-  var names = {openai:'OpenAI',gemini:'Gemini',openrouter:'OpenRouter',anthropic:'Anthropic',ollama:'Ollama'};
+  var names = {openai:'OpenAI',gemini:'Gemini',openrouter:'OpenRouter',anthropic:'Anthropic',ollama:'Ollama',llamaserver:'llama.cpp'};
   var mn = m.split('/').pop();
   document.getElementById('model-label').textContent = (names[p] || p) + (mn ? ' · ' + mn : '');
 }
@@ -1073,17 +1120,56 @@ function startAIBubble() {
   var bub = document.createElement('div');
   bub.id        = 'streaming-bubble';
   bub.className = 'bubble';
+  var ans = document.createElement('div');   // answer goes here, below any thinking block
+  ans.className = 'stream-answer';
+  bub.appendChild(ans);
   row.appendChild(bub);
   chat.appendChild(row);
   _streamBubble = bub;
+  _streamAnswer = ans;
   _streamRaw    = '';
+  _streamThink  = '';
+  _thinkEl      = null;
   chat.scrollTop = chat.scrollHeight;
+}
+
+// Reasoning models (e.g. Qwen3, DeepSeek-R1 via llama.cpp / OpenRouter) stream
+// their chain-of-thought separately in delta.reasoning_content. Show it in a
+// collapsible "Thinking" disclosure above the answer so the bubble isn't blank
+// while the model reasons, and so reasoning never pollutes the saved answer.
+function appendThinking(chunk) {
+  if (!_streamBubble) return;
+  if (!_thinkEl) {
+    _thinkEl = document.createElement('details');
+    _thinkEl.open = true;
+    _thinkEl.style.cssText = 'margin-bottom:6px;font-size:0.92em';
+    var sum = document.createElement('summary');
+    sum.textContent = 'Thinking…';
+    sum.style.cssText = 'color:var(--text-muted);cursor:pointer;user-select:none';
+    var body = document.createElement('div');
+    body.style.cssText = 'color:var(--text-muted);white-space:pre-wrap;margin-top:4px;'
+      + 'padding-left:8px;border-left:2px solid var(--text-muted);opacity:0.85';
+    _thinkEl.appendChild(sum);
+    _thinkEl.appendChild(body);
+    _thinkEl._body = body;
+    _streamBubble.insertBefore(_thinkEl, _streamAnswer);
+  }
+  _streamThink += chunk;
+  _thinkEl._body.textContent = _streamThink;
+  var chat = document.getElementById('chat');
+  if (chat) chat.scrollTop = chat.scrollHeight;
 }
 
 function appendChunk(chunk) {
   if (!_streamBubble) return;
+  // First real answer token: collapse the thinking disclosure.
+  if (_thinkEl && _streamRaw === '') {
+    _thinkEl.open = false;
+    var s = _thinkEl.querySelector('summary');
+    if (s) s.textContent = 'Thoughts';
+  }
   _streamRaw += chunk;
-  _streamBubble.innerHTML = renderMarkdown(_streamRaw);
+  _streamAnswer.innerHTML = renderMarkdown(_streamRaw);
   var chat = document.getElementById('chat');
   if (chat) chat.scrollTop = chat.scrollHeight;
 }
@@ -1093,10 +1179,13 @@ function finalizeResponse() {
     var row = document.getElementById('streaming-row');
     if (row) row.removeAttribute('id');
     _streamBubble.removeAttribute('id');
-    _streamBubble.innerHTML = renderMarkdown(_streamRaw);
+    if (_streamAnswer) _streamAnswer.innerHTML = renderMarkdown(_streamRaw);
   }
   _streamBubble = null;
+  _streamAnswer = null;
   _streamRaw    = '';
+  _streamThink  = '';
+  _thinkEl      = null;
   setBusy(false);
   var chat = document.getElementById('chat');
   if (chat) chat.scrollTop = chat.scrollHeight;
@@ -1106,7 +1195,10 @@ function cancelStream() {
   var row = document.getElementById('streaming-row');
   if (row) row.remove();
   _streamBubble = null;
+  _streamAnswer = null;
   _streamRaw    = '';
+  _streamThink  = '';
+  _thinkEl      = null;
   hideTyping();
   setBusy(false);
 }


### PR DESCRIPTION
## Summary

Adds a **"llama.cpp Server (Local)"** AI provider so users can point the AI assistant at any OpenAI-compatible [`llama-server`](https://github.com/ggml-org/llama.cpp/tree/master/tools/server) endpoint and run fully local models without Ollama.

## What's included

- **New provider** wired into the streaming dispatcher, targeting `{endpoint}/v1/chat/completions`. Base URL is configurable (default `http://localhost:8080`); the `/v1` path is appended automatically.
- **Optional API key** — only sent when set (for servers started with `--api-key`), so keyless local servers work out of the box. `_stream_openai_compat` now omits the `Authorization` header when no key is present.
- **Server Status check** (`check_llama`) hits `/v1/models` to confirm reachability and suggest the loaded model name, mirroring the existing Ollama status UI.
- **Reasoning-model support**: streams `delta.reasoning_content` (llama.cpp / Qwen / DeepSeek) and `delta.reasoning` (OpenRouter) into a collapsible **"Thinking"** disclosure above the answer, kept out of the saved conversation. Without this, reasoning models show a blank bubble while thinking and can return an empty reply if the token budget is spent on reasoning. This also improves OpenAI/OpenRouter reasoning models.

## Testing

Tested end-to-end against a `llama-server` running **Qwen3.5-9B**:
- `GET /v1/models` returns the loaded model ✓
- Streaming chat completion: reasoning streams to the "Thinking" area, final answer streams to the bubble ✓
- `python -m py_compile` clean ✓

## Notes

Self-contained: new provider plus a small, backward-compatible refactor of the streaming bubble (answer rendered into a sub-element so a "Thinking" block can sit above it). No changes to existing providers' behavior beyond the additive reasoning channel.