### PR TITLE
Add custom OpenAI-compatible AI provider

### DIFF
--- a/ai_assistant.py
+++ b/ai_assistant.py
@@ -157,6 +157,9 @@ CK_KEY_OPENAI = _PFX + "key_openai"
 CK_KEY_GEMINI = _PFX + "key_gemini"
 CK_KEY_OR     = _PFX + "key_openrouter"
 CK_KEY_ANTH   = _PFX + "key_anthropic"
+CK_KEY_CUSTOM_OPENAI = _PFX + "key_custom_openai"
+CK_CUSTOM_BASE_URL   = _PFX + "custom_openai_base_url"
+CK_CUSTOM_MODEL      = _PFX + "custom_openai_model"
 CK_OLLAMA_EP  = _PFX + "ollama_endpoint"
 CK_OLLAMA_MDL = _PFX + "ollama_model"
 CK_LANGUAGE   = _PFX + "language"
@@ -233,15 +236,23 @@ def _cfg_set(key: str, value: Any) -> None:
 def _load_settings() -> Dict[str, Any]:
     provider = _cfg_get(CK_PROVIDER, "openai")
     key_map  = {
-        "openai":     _cfg_get(CK_KEY_OPENAI, ""),
-        "gemini":     _cfg_get(CK_KEY_GEMINI, ""),
-        "openrouter": _cfg_get(CK_KEY_OR,     ""),
-        "anthropic":  _cfg_get(CK_KEY_ANTH,   ""),
+        "openai":        _cfg_get(CK_KEY_OPENAI, ""),
+        "gemini":        _cfg_get(CK_KEY_GEMINI, ""),
+        "openrouter":    _cfg_get(CK_KEY_OR,     ""),
+        "anthropic":     _cfg_get(CK_KEY_ANTH,   ""),
+        "custom_openai": _cfg_get(CK_KEY_CUSTOM_OPENAI, ""),
     }
-    current_key    = key_map.get(provider, "")
-    ollama_ep      = _cfg_get(CK_OLLAMA_EP, OLLAMA_EP_DEFAULT)
-    ollama_model   = _cfg_get(CK_OLLAMA_MDL, "")
-    effective_model = ollama_model if provider == "ollama" else _cfg_get(CK_MODEL, "")
+    current_key     = key_map.get(provider, "")
+    custom_base_url = _cfg_get(CK_CUSTOM_BASE_URL, "")
+    ollama_ep       = _cfg_get(CK_OLLAMA_EP, OLLAMA_EP_DEFAULT)
+    ollama_model    = _cfg_get(CK_OLLAMA_MDL, "")
+    custom_model    = _cfg_get(CK_CUSTOM_MODEL, "")
+    if provider == "ollama":
+        effective_model = ollama_model
+    elif provider == "custom_openai":
+        effective_model = custom_model
+    else:
+        effective_model = _cfg_get(CK_MODEL, "")
     return {
         "provider":     provider,
         "model":        effective_model,
@@ -250,21 +261,34 @@ def _load_settings() -> Dict[str, Any]:
         "source":       _cfg_get(CK_SOURCE,    "Front & Back"),
         "ownPrompt":    _cfg_get(CK_OWN_PROMPT, DEFAULT_OWN_PROMPT),
         "ollamaEndpoint": ollama_ep,
+        "customBaseUrl":  custom_base_url,
         "isDark":         _detect_night_mode(),
-        "isConfigured":   _is_configured(provider, current_key),
+        "isConfigured":   _is_configured(provider, current_key, effective_model, custom_base_url),
         "chipsConfig":    _cfg_get(CK_CHIPS, _DEFAULT_CHIPS),
         "accentColor":    _get_theme_accent(_detect_night_mode()),
         "fontSize":       _cfg_get(CK_FONT_SIZE, "13px"),
     }
 
-def _is_configured(provider: str, api_key: str) -> bool:
-    return provider == "ollama" or bool(api_key and api_key.strip())
+def _is_configured(
+    provider: str,
+    api_key: str,
+    model: str = "",
+    custom_base_url: str = "",
+) -> bool:
+    if provider == "ollama":
+        return True
+    if provider == "custom_openai":
+        return bool(api_key and api_key.strip()
+                    and model and model.strip()
+                    and custom_base_url and custom_base_url.strip())
+    return bool(api_key and api_key.strip())
 
 def _save_settings_dict(data: Dict[str, Any]) -> None:
-    provider  = data.get("provider", "openai")
-    api_key   = data.get("apiKey", "").strip()
-    model     = data.get("model", "").strip()
-    ollama_ep = data.get("ollamaEndpoint", OLLAMA_EP_DEFAULT).strip() or OLLAMA_EP_DEFAULT
+    provider        = data.get("provider", "openai")
+    api_key         = data.get("apiKey", "").strip()
+    model           = data.get("model", "").strip()
+    custom_base_url = data.get("customBaseUrl", "").strip()
+    ollama_ep       = data.get("ollamaEndpoint", OLLAMA_EP_DEFAULT).strip() or OLLAMA_EP_DEFAULT
 
     _cfg_set(CK_PROVIDER,   provider)
     _cfg_set(CK_LANGUAGE,   data.get("language",  "English"))
@@ -274,10 +298,16 @@ def _save_settings_dict(data: Dict[str, Any]) -> None:
         _cfg_set(CK_FONT_SIZE, font_size)
     _cfg_set(CK_OWN_PROMPT, data.get("ownPrompt", DEFAULT_OWN_PROMPT))
     _cfg_set(CK_OLLAMA_EP,  ollama_ep)
+    _cfg_set(CK_CUSTOM_BASE_URL, custom_base_url)
 
     if provider == "ollama":
         if model:
             _cfg_set(CK_OLLAMA_MDL, model)
+    elif provider == "custom_openai":
+        if model:
+            _cfg_set(CK_CUSTOM_MODEL, model)
+        if api_key:
+            _cfg_set(CK_KEY_CUSTOM_OPENAI, api_key)
     else:
         if model:
             _cfg_set(CK_MODEL, model)
@@ -290,9 +320,32 @@ def _save_settings_dict(data: Dict[str, Any]) -> None:
         if provider in key_cfg and api_key:
             _cfg_set(key_cfg[provider], api_key)
 
+    endpoint_label = "custom" if provider == "custom_openai" else (ollama_ep if provider == "ollama" else "n/a")
     print(f"AI Assistant: settings saved — provider={provider}, model={model}, "
-          f"endpoint={ollama_ep if provider=='ollama' else 'n/a'}, "
-          f"key={'(set)' if api_key else '(empty)'}")
+          f"endpoint={endpoint_label}, key={'(set)' if api_key else '(empty)'}")
+
+
+def _openai_compat_chat_url(base_url: str) -> str:
+    base = (base_url or "").strip()
+    if not base:
+        raise ValueError("Enter a Base URL for the custom provider.")
+    parsed = urllib.parse.urlparse(base)
+    if parsed.scheme not in ("http", "https") or not parsed.netloc:
+        raise ValueError("Base URL must start with http:// or https://.")
+    base = base.rstrip("/")
+    if base.endswith("/chat/completions"):
+        return base
+    return base + "/chat/completions"
+
+
+def _validate_custom_openai_settings(api_key: str, model: str, custom_base_url: str) -> str:
+    if not custom_base_url or not custom_base_url.strip():
+        raise ValueError("Enter a Base URL for the custom provider.")
+    if not api_key or not api_key.strip():
+        raise ValueError("Enter an API key for the custom provider.")
+    if not model or not model.strip():
+        raise ValueError("Enter a model name for the custom provider.")
+    return _openai_compat_chat_url(custom_base_url)
 
 
 # ══════════════════════════════════════════════════════════════════════════════
@@ -331,6 +384,11 @@ def _classify_error(exc: Exception, provider: str = "") -> str:
             detail = body or exc.reason or "bad request"
             return f"Bad request (HTTP 400): {detail}"
         elif code == 404:
+            if provider == "custom_openai":
+                return (
+                    "Endpoint not found (HTTP 404). Check that the Base URL is an "
+                    "OpenAI-compatible /v1 API root and that the model name is correct."
+                )
             return (
                 f"Model not found (HTTP 404). "
                 "Check that the model name in Settings is correct."
@@ -396,11 +454,12 @@ def _stream_openai_compat(
     on_chunk: Callable[[str], None],
     extra_headers: Optional[Dict[str, str]] = None,
     timeout: int = 60,
+    max_tokens: int = 2048,
 ) -> None:
     """OpenAI-compatible streaming (also used for OpenRouter)."""
     print(f"AI Assistant: streaming OpenAI-compat url={url.split('/')[2]}, model={model}")
     payload = json.dumps({
-        "model": model, "messages": messages, "max_tokens": 2048, "stream": True,
+        "model": model, "messages": messages, "max_tokens": max_tokens, "stream": True,
     }).encode("utf-8")
     headers: Dict[str, str] = {
         "Authorization": f"Bearer {api_key}",
@@ -582,10 +641,11 @@ def _js_on_main(code: str) -> None:
 def _run_api_in_thread(settings: Dict[str, Any], messages: List[Dict]) -> None:
     """Stream API response token by token; each chunk is dispatched to the webview."""
     def worker() -> None:
-        provider  = settings.get("provider", "?")
-        model     = settings.get("model", "")
-        api_key   = settings.get("apiKey", "")
-        ollama_ep = settings.get("ollamaEndpoint", OLLAMA_EP_DEFAULT)
+        provider        = settings.get("provider", "?")
+        model           = settings.get("model", "")
+        api_key         = settings.get("apiKey", "")
+        ollama_ep       = settings.get("ollamaEndpoint", OLLAMA_EP_DEFAULT)
+        custom_base_url = settings.get("customBaseUrl", "")
         full_text: List[str] = []
 
         if not model:
@@ -617,6 +677,12 @@ def _run_api_in_thread(settings: Dict[str, Any], messages: List[Dict]) -> None:
                         "X-Title":      "SynapsePro",
                     },
                 )
+            elif provider == "custom_openai":
+                custom_url = _validate_custom_openai_settings(api_key, model, custom_base_url)
+                _stream_openai_compat(
+                    custom_url,
+                    api_key, model, messages, on_chunk,
+                )
             elif provider == "anthropic":
                 _stream_anthropic(api_key, model, messages, on_chunk)
             elif provider == "ollama":
@@ -633,7 +699,7 @@ def _run_api_in_thread(settings: Dict[str, Any], messages: List[Dict]) -> None:
             err_msg = _classify_error(exc, provider)
             _EXPECTED = (urllib.error.HTTPError, urllib.error.URLError,
                          TimeoutError, socket.timeout, json.JSONDecodeError,
-                         RuntimeError)
+                         RuntimeError, ValueError)
             if isinstance(exc, _EXPECTED):
                 print(f"AI Assistant: API error [{provider}] {type(exc).__name__}: {exc}")
             else:
@@ -832,14 +898,15 @@ else:
 
 def _handle_action(action: str, data: Dict[str, Any]) -> None:
     dispatch = {
-        "page_ready":    _action_page_ready,
-        "send_message":  _action_send_message,
-        "chip_action":   _action_chip,
-        "save_settings": _action_save_settings,
-        "save_chips":    _action_save_chips,
-        "check_ollama":  _action_check_ollama,
-        "setup_ollama":  _action_setup_ollama,
-        "clear_history": _action_clear_history,
+        "page_ready":       _action_page_ready,
+        "send_message":     _action_send_message,
+        "chip_action":      _action_chip,
+        "save_settings":    _action_save_settings,
+        "save_chips":       _action_save_chips,
+        "test_connection":  _action_test_connection,
+        "check_ollama":     _action_check_ollama,
+        "setup_ollama":     _action_setup_ollama,
+        "clear_history":    _action_clear_history,
     }
     handler = dispatch.get(action)
     if handler:
@@ -868,9 +935,17 @@ def _action_send_message(data: Dict[str, Any]) -> None:
     print(f"AI Assistant: send_message provider={provider}, "
           f"model={settings['model']}, key={'(set)' if api_key else '(empty)'}")
 
-    if not _is_configured(provider, api_key):
+    if not _is_configured(
+        provider,
+        api_key,
+        settings.get("model", ""),
+        settings.get("customBaseUrl", ""),
+    ):
         print("AI Assistant: not configured – showing error")
-        _run_js('receiveResponse("No API key configured. Open Settings (⚙) and enter your API key.", true);')
+        if provider == "custom_openai":
+            _run_js('receiveResponse("Custom OpenAI Compatible is not configured. Open Settings (⚙) and enter Base URL, API Key, and Model.", true);')
+        else:
+            _run_js('receiveResponse("No API key configured. Open Settings (⚙) and enter your API key.", true);')
         return
 
     _conversation.append({"role": "user", "content": text})
@@ -891,8 +966,16 @@ def _action_chip(data: Dict[str, Any]) -> None:
     provider = settings["provider"]
     api_key  = settings["apiKey"]
 
-    if not _is_configured(provider, api_key):
-        _run_js('receiveResponse("No API key configured. Open Settings (⚙) and enter your API key.", true);')
+    if not _is_configured(
+        provider,
+        api_key,
+        settings.get("model", ""),
+        settings.get("customBaseUrl", ""),
+    ):
+        if provider == "custom_openai":
+            _run_js('receiveResponse("Custom OpenAI Compatible is not configured. Open Settings (⚙) and enter Base URL, API Key, and Model.", true);')
+        else:
+            _run_js('receiveResponse("No API key configured. Open Settings (⚙) and enter your API key.", true);')
         return
 
     if action == "custom":
@@ -918,6 +1001,50 @@ def _action_chip(data: Dict[str, Any]) -> None:
 def _action_save_settings(data: Dict[str, Any]) -> None:
     _save_settings_dict(data)
     tooltip(_("AI settings saved."))
+
+
+def _action_test_connection(data: Dict[str, Any]) -> None:
+    """Test unsaved custom OpenAI-compatible settings without persisting them."""
+    provider        = data.get("provider", "")
+    api_key         = data.get("apiKey", "").strip()
+    model           = data.get("model", "").strip()
+    custom_base_url = data.get("customBaseUrl", "").strip()
+
+    if provider != "custom_openai":
+        _js_on_main("setTestConnectionResult({ok:false,message:'Test Connection is available for Custom OpenAI Compatible only.'});")
+        return
+
+    def send_result(ok: bool, message: str) -> None:
+        payload = json.dumps({"ok": ok, "message": message})
+        _js_on_main(f"setTestConnectionResult({payload});")
+
+    try:
+        custom_url = _validate_custom_openai_settings(api_key, model, custom_base_url)
+    except Exception as exc:
+        send_result(False, str(exc))
+        return
+
+    def worker() -> None:
+        try:
+            chunks: List[str] = []
+            messages = [
+                {"role": "system", "content": "You are a connection test. Reply with OK only."},
+                {"role": "user", "content": "Test"},
+            ]
+            _stream_openai_compat(
+                custom_url,
+                api_key,
+                model,
+                messages,
+                lambda chunk: chunks.append(chunk),
+                timeout=15,
+                max_tokens=8,
+            )
+            send_result(True, "Connection successful.")
+        except Exception as exc:
+            send_result(False, _classify_error(exc, "custom_openai"))
+
+    threading.Thread(target=worker, daemon=True).start()
 
 
 def _action_save_chips(data: Dict[str, Any]) -> None:

--- a/chat_ui.html
+++ b/chat_ui.html
@@ -68,6 +68,14 @@ body{font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",Helvetica,Arial,san
 .s-save:hover{opacity:.82}
 #ollama-status-line{font-size:11px;color:var(--text-muted);line-height:1.5}
 #ollama-status-line a{color:inherit;text-decoration:underline;cursor:pointer}
+.s-test-btn{width:100%;background:var(--surface);color:var(--text);border:1px solid var(--border);
+  border-radius:8px;padding:7px 10px;font-size:12px;font-weight:600;cursor:pointer;
+  font-family:inherit;transition:background .12s,border-color .12s,opacity .12s}
+.s-test-btn:hover:not(:disabled){background:var(--chip-bg);border-color:var(--text-muted)}
+.s-test-btn:disabled{opacity:.55;cursor:default}
+#s-test-result{font-size:11px;color:var(--text-muted);line-height:1.4;margin-top:5px;min-height:15px}
+#s-test-result.ok{color:var(--success)}
+#s-test-result.fail{color:var(--error)}
 
 
 /* ── Info panel ── */
@@ -324,6 +332,7 @@ body:not(.empty) #disclaimer{display:block}
         <option value="gemini">Google Gemini</option>
         <option value="openrouter">OpenRouter</option>
         <option value="anthropic">Anthropic Claude</option>
+        <option value="custom_openai">Custom OpenAI Compatible</option>
         <option value="ollama">Ollama (Local)</option>
       </select>
     </div>
@@ -336,6 +345,15 @@ body:not(.empty) #disclaimer{display:block}
       <input class="s-input" id="s-model" list="s-model-list" placeholder="Select or type a model..." autocomplete="off"/>
       <datalist id="s-model-list"></datalist>
       <div class="s-hint">Pick from the list or type a custom model name.</div>
+    </div>
+    <div class="s-row" id="s-custom-base-url-row" style="display:none">
+      <label class="s-label">Base URL</label>
+      <input class="s-input" type="url" id="s-custom-base-url" placeholder="https://api.example.com/v1" autocomplete="off"/>
+      <div class="s-hint">Use the OpenAI-compatible API root, usually ending in /v1.</div>
+    </div>
+    <div class="s-row" id="s-test-row" style="display:none">
+      <button class="s-test-btn" id="s-test-btn" onclick="testConnection()">Test Connection</button>
+      <div id="s-test-result"></div>
     </div>
     <div class="s-row" id="s-ollama-ep-row" style="display:none">
       <label class="s-label">Ollama Endpoint</label>
@@ -401,6 +419,7 @@ body:not(.empty) #disclaimer{display:block}
         <b>Google Gemini</b> (flash) — free tier available, very capable.<br>
         <b>Anthropic Claude</b> — strong at nuanced explanations.<br>
         <b>OpenRouter</b> — access many models with one key, includes free options.<br>
+        <b>Custom OpenAI Compatible</b> — use any trusted service that supports OpenAI-style chat completions.<br>
         <b>Ollama</b> — runs 100% locally on your machine, no key, no cost, no data leaves your device.
       </div>
     </div>
@@ -425,7 +444,8 @@ body:not(.empty) #disclaimer{display:block}
         <b>Your API key is stored only on this device</b> in Anki's local config — it is never
         uploaded to any server by this add-on.<br><br>
         When you send a message, your question and card content go directly to the provider you
-        chose (OpenAI, Google, etc.) under <b>their</b> privacy policy.
+        chose (OpenAI, Google, your custom Base URL, etc.) under <b>their</b> privacy policy.
+        Only use a custom OpenAI-compatible endpoint if you trust that provider.
         If privacy is critical, use <b>Ollama</b> — everything stays local.<br><br>
         SynapseGPT does <b>not</b> collect analytics, logs, or usage data.
       </div>
@@ -532,6 +552,7 @@ var MODELS = {
     'deepseek/deepseek-chat-v3-0324:free','mistralai/mistral-7b-instruct:free'
   ],
   anthropic:  ['claude-haiku-4-5-20251001','claude-sonnet-4-6','claude-opus-4-6'],
+  custom_openai: [],
   ollama:     []
 };
 
@@ -596,6 +617,7 @@ function init(cfg) {
   safeSet('s-language', cfg.language  || 'English');
   safeSet('s-source',   cfg.source    || 'Front Only');
   document.getElementById('s-ollama-ep').value = cfg.ollamaEndpoint || 'http://localhost:11434';
+  document.getElementById('s-custom-base-url').value = cfg.customBaseUrl || '';
 
   // Accent color
   var accent = cfg.accentColor || (cfg.isDark ? '#6366f1' : '#3b82f6');
@@ -889,21 +911,27 @@ function onProviderChange(resetModel) {
   if (resetModel === undefined) resetModel = true;
   var prov     = document.getElementById('s-provider').value;
   var isOllama = prov === 'ollama';
+  var isCustom = prov === 'custom_openai';
   document.getElementById('s-apikey-row').style.display    = isOllama ? 'none' : '';
   document.getElementById('s-ollama-ep-row').style.display = isOllama ? '' : 'none';
   document.getElementById('s-ollama-row').style.display    = isOllama ? '' : 'none';
+  document.getElementById('s-custom-base-url-row').style.display = isCustom ? '' : 'none';
+  document.getElementById('s-test-row').style.display = isCustom ? '' : 'none';
+  if (!isCustom) setTestConnectionResult({ ok: null, message: '' });
   var inp = document.getElementById('s-model');
   var dl  = document.getElementById('s-model-list');
   dl.innerHTML = '';
-  if (!isOllama) {
+  if (isOllama) {
+    inp.placeholder = 'Fetching models...';
+    sendToPython('check_ollama', {});
+  } else if (isCustom) {
+    inp.placeholder = 'Enter model name, e.g. gpt-4o-mini';
+  } else {
     (MODELS[prov] || []).forEach(function(m) {
       var o = document.createElement('option'); o.value = m; dl.appendChild(o);
     });
     if (resetModel && MODELS[prov] && MODELS[prov].length) inp.value = MODELS[prov][0];
     inp.placeholder = 'Select or type a model...';
-  } else {
-    inp.placeholder = 'Fetching models...';
-    sendToPython('check_ollama', {});
   }
 }
 
@@ -931,8 +959,8 @@ function setOllamaStatus(status, models) {
   }
 }
 
-function saveSettings() {
-  var data = {
+function collectSettingsFormData() {
+  return {
     provider:       document.getElementById('s-provider').value,
     model:          document.getElementById('s-model').value.trim(),
     apiKey:         document.getElementById('s-apikey').value.trim(),
@@ -940,13 +968,19 @@ function saveSettings() {
     source:         document.getElementById('s-source').value,
     ownPrompt:      '',
     ollamaEndpoint: document.getElementById('s-ollama-ep').value.trim() || 'http://localhost:11434',
+    customBaseUrl:  document.getElementById('s-custom-base-url').value.trim(),
     fontSize:       document.getElementById('s-fontsize').value || '13px'
   };
-  setFontSize(data.fontSize);
-  console.log('AI Assistant: save_settings provider=' + data.provider + ' model=' + data.model);
-  sendToPython('save_settings', data);
-  var banner    = document.getElementById('setup-banner');
-  var configured = (data.provider === 'ollama') || !!data.apiKey;
+}
+
+function isSettingsConfigured(data) {
+  if (data.provider === 'ollama') return true;
+  if (data.provider === 'custom_openai') return !!(data.customBaseUrl && data.apiKey && data.model);
+  return !!data.apiKey;
+}
+
+function updateSetupBanner(configured) {
+  var banner = document.getElementById('setup-banner');
   if (configured) {
     banner.style.display = 'none';
     delete banner.dataset.showOnActive;
@@ -957,14 +991,46 @@ function saveSettings() {
       banner.dataset.showOnActive = '1';
     }
   }
+}
+
+function saveSettings() {
+  var data = collectSettingsFormData();
+  setFontSize(data.fontSize);
+  console.log('AI Assistant: save_settings provider=' + data.provider + ' model=' + data.model);
+  sendToPython('save_settings', data);
+  updateSetupBanner(isSettingsConfigured(data));
   updateModelLabel();
   closeSettings();
+}
+
+function testConnection() {
+  var data = collectSettingsFormData();
+  if (data.provider !== 'custom_openai') return;
+  if (!data.customBaseUrl) { setTestConnectionResult({ ok:false, message:'Enter a Base URL for the custom provider.' }); return; }
+  if (!/^https?:\/\//i.test(data.customBaseUrl)) { setTestConnectionResult({ ok:false, message:'Base URL must start with http:// or https://.' }); return; }
+  if (!data.apiKey) { setTestConnectionResult({ ok:false, message:'Enter an API key for the custom provider.' }); return; }
+  if (!data.model) { setTestConnectionResult({ ok:false, message:'Enter a model name for the custom provider.' }); return; }
+  var btn = document.getElementById('s-test-btn');
+  if (btn) btn.disabled = true;
+  setTestConnectionResult({ ok:null, message:'Testing connection...' });
+  sendToPython('test_connection', data);
+}
+
+function setTestConnectionResult(result) {
+  var el = document.getElementById('s-test-result');
+  if (!el) return;
+  var btn = document.getElementById('s-test-btn');
+  el.className = '';
+  el.textContent = (result && result.message) || '';
+  if (result && result.ok === true) el.classList.add('ok');
+  if (result && result.ok === false) el.classList.add('fail');
+  if (btn && (!result || result.message !== 'Testing connection...')) btn.disabled = false;
 }
 
 function updateModelLabel() {
   var p = document.getElementById('s-provider').value;
   var m = document.getElementById('s-model').value || '';
-  var names = {openai:'OpenAI',gemini:'Gemini',openrouter:'OpenRouter',anthropic:'Anthropic',ollama:'Ollama'};
+  var names = {openai:'OpenAI',gemini:'Gemini',openrouter:'OpenRouter',anthropic:'Anthropic',custom_openai:'Custom',ollama:'Ollama'};
   var mn = m.split('/').pop();
   document.getElementById('model-label').textContent = (names[p] || p) + (mn ? ' · ' + mn : '');
 }


### PR DESCRIPTION
## Summary
- add a `Custom OpenAI Compatible` provider option to SynapseGPT settings
- persist custom Base URL, API key, and model separately from built-in providers
- route custom provider requests through the existing OpenAI-compatible streaming helper
- add a Test Connection button for unsaved custom provider settings

## Verification
- `uv run python -m py_compile G:\01_Workspace\SynapsePro\ai_assistant.py`
- embedded `chat_ui.html` JavaScript syntax checked with Node
- `git diff --check`
- copied modified add-on into `C:\Users\27987\AppData\Roaming\Anki2\addons21\SynapsePro` and restarted Anki; user confirmed it was OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)