### PR TITLE
Fix: exclude type=4 (manual reschedule) entries from Consistency streak

### DIFF
--- a/statistics_widget.py
+++ b/statistics_widget.py
@@ -40,7 +40,7 @@ def get_statistics_data(stats_days=7):
         day_start_ts = int(datetime(day.year, day.month, day.day).timestamp())
 
         count = mw.col.db.scalar(
-            "SELECT COUNT(*) FROM revlog WHERE id >= ? AND id < ?",
+            "SELECT COUNT(*) FROM revlog WHERE id >= ? AND id < ? AND type !=4",
             day_start_ts * 1000,
             (day_start_ts + 86400) * 1000,
         )


### PR DESCRIPTION
Fixes #16.

`get_statistics_data()` checks `count > 0` per day to build the 
Consistency streak, but the underlying query counts all revlog rows 
regardless of type — including type=4 (manual reschedules). On a day 
with no real study activity but reschedule entries (e.g. from an FSRS 
re-optimization), this incorrectly marks the day green instead of gray.

Note: this is the same root cause reported in #16, but that report's 
concrete fix targets `get_daily_review_counts()` in the currently 
shipped v1.4.0, which isn't present on `main` yet (see my comment on 
the issue for details). This PR fixes the analogous bug in the 
`main` branch's current streak-detection code.